### PR TITLE
Caching updates

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -21,3 +21,4 @@ parameters:
     api_token: ~
     api_url: ~
     admin_password: ~
+    container.autowiring.strict_mode: true

--- a/src/AppBundle/Cache/ApiService.php
+++ b/src/AppBundle/Cache/ApiService.php
@@ -34,11 +34,6 @@ class ApiService
     CONST TOKEN_TYPE_DATA = 2;
 
     /**
-     * @var int the time in seconds that the cache should be invalidated
-     */
-    private $cache_timeout = 1800;
-
-    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -51,21 +46,6 @@ class ApiService
     private function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
-    }
-
-
-    /**
-     * The internal cache needs to be renewed every half hour since this is when the
-     * machines will updated there status'.  This will calculated when the last half
-     * hour passed for comparing if the cache should still be used or updated
-     *
-     * @return int
-     */
-    private function getCacheTimeout()
-    {
-        //Find how far off the prior interval we are
-        //Removing this offset takes us to the "round down" half hour
-        return time() - (time() % $this->cache_timeout);
     }
 
     /**
@@ -105,7 +85,7 @@ class ApiService
 
         $has_cache = $cache->has($time_token) && $cache->has($data_token);
 
-        if ($has_cache && $cache->get($time_token) >= $this->getCacheTimeout()) {
+        if ($has_cache && $cache->get($time_token)) {
             $result = $cache->get($data_token);
             $this->logger->info('Cache result', $result);
             $this->logger->info('Cache Time', ['timestamp' => $cache->get($time_token)]);
@@ -119,8 +99,37 @@ class ApiService
         return $result;
     }
 
+    /**
+     * @param string $grouping
+     * @param string $api_url
+     * @param string $api_token
+     *
+     * @return array
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws \Exception
+     */
+    private function getLiveServerGroup(string $grouping, string $api_url, string $api_token){
+        $cache = new FilesystemCache();
+
+        $time_token = $this->generateCacheToken(self::TOKEN_TYPE_TIME, $grouping);
+        $data_token = $this->generateCacheToken(self::TOKEN_TYPE_DATA, $grouping);
+
+        $result = Client::create($api_token, $api_url, $grouping)->group();
+        $this->logger->info('Api result', $result);
+        $cache->set($data_token, $result);
+        $cache->set($time_token, time());
+
+        return $result;
+
+    }
+
     static public function getServerGroupData(string $grouping, string $api_url, string $api_token, LoggerInterface $logger){
         $self = new self($logger);
         return $self->getServerGroup($grouping, $api_url, $api_token);
+    }
+
+    static public function updateServerCacheData(string $grouping, string $api_url, string $api_token, LoggerInterface $logger){
+        $self = new self($logger);
+        return $self->getLiveServerGroup($grouping, $api_url, $api_token);
     }
 }

--- a/src/AppBundle/Cache/ServerWarmer.php
+++ b/src/AppBundle/Cache/ServerWarmer.php
@@ -76,7 +76,7 @@ class ServerWarmer implements CacheWarmerInterface
          * @var Server $server
          */
         foreach ($servers as $server) {
-            ApiService::getServerGroupData(
+            ApiService::updateServerCacheData(
                 $server->getName(),
                 $url,
                 $token,

--- a/web/assets/js/ServerInfo.js
+++ b/web/assets/js/ServerInfo.js
@@ -104,16 +104,17 @@ $.widget("howe.ServerInfo", {
      * @private
      */
     __intervalRefreshTime: function () {
-        let refreshInterval;
+        let refreshInterval = 5; // minutes
         let now = new Date();
         let next = new Date();
-        next.setMinutes(Math.ceil(next.getMinutes() / 30) * 30);
+        let result;
+        next.setMinutes(Math.ceil(next.getMinutes() / refreshInterval) * refreshInterval);
 
-        refreshInterval = next - now;
+        result = next - now;
 
-        /* between 1 and 5 minutes */
-        refreshInterval += this.__randomTime(60 * 1000, 5 * 60 * 1000);
-        return refreshInterval;
+        /* between 0 and 1 minutes */
+        result += this.__randomTime(0, 60 * 1000);
+        return result;
 
     },
 


### PR DESCRIPTION
This is an update to the caching methodology.
Main Changes

- The Api will return a cached result inless the update=1 query parameter is added
- There is a refreshGroupings api action available for forcing cache updates.
- All the timeout references have been removed.