### PR TITLE
Issue #51 Replace AccuWeather Images

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -15,6 +15,8 @@
     <link rel="stylesheet" type="text/css" href="{{ asset('vendor/morrisjs/morris.css') }}"/>
     <!-- Custom Fonts -->
     <link rel="stylesheet" type="text/css" href="{{ asset('bundles/font-awesome/css/font-awesome.min.css') }}"/>
+    <!-- Weather Fonts -->
+    <link rel="stylesheet" type="text/css" href="{{ asset('bundles/weathericons/css/weather-icons.min.css') }}"/>
 {% block style %}{% endblock %}
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "font-awesome": "4.7.x",
     "jquery": "3.4.x",
-    "moment": "2.19.x"
+    "moment": "2.19.x",
+    "weathericons": "2.0.x"
   }
 }

--- a/src/Statusboard/Weather/Accuweather/Transform.php
+++ b/src/Statusboard/Weather/Accuweather/Transform.php
@@ -111,6 +111,10 @@ class Transform implements ApiResponseInterface {
                     'day' => self::generateIconImageUrl($body['DailyForecasts'][$day]['Day']['Icon']),
                     'night' => self::generateIconImageUrl($body['DailyForecasts'][$day]['Night']['Icon']),
                 ],
+                'weather-icons' => [
+                    'day' => TranslateIconsToWeatherIcon::map($body['DailyForecasts'][$day]['Day']['Icon']),
+                    'night' => TranslateIconsToWeatherIcon::map($body['DailyForecasts'][$day]['Night']['Icon']),
+                ],
                 'icontext' => [
                     'day' => self::extractIconPhrase($body['DailyForecasts'][$day]['Day']),
                     'night' => self::extractIconPhrase($body['DailyForecasts'][$day]['Night'])
@@ -123,7 +127,8 @@ class Transform implements ApiResponseInterface {
             'condition' => $body['current'][0]['WeatherText'],
             'temp' => self::formatNumber($body['current'][0]['Temperature']['Imperial']['Value']),
             'link' => $body['current'][0]['Link'],
-            'icon' => self::generateIconImageUrl($body['current'][0]['WeatherIcon'])
+            'icon' => self::generateIconImageUrl($body['current'][0]['WeatherIcon']),
+            'weather-icon' => TranslateIconsToWeatherIcon::map($body['current'][0]['WeatherIcon'])
         ];
         return $output;
     }

--- a/src/Statusboard/Weather/Accuweather/TranslateIconsToWeatherIcon.php
+++ b/src/Statusboard/Weather/Accuweather/TranslateIconsToWeatherIcon.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace Statusboard\Weather\Accuweather;
+
+
+class TranslateIconsToWeatherIcon {
+
+    public static function map(int $accuweather_icon_number){
+        switch ($accuweather_icon_number){
+            case 1: // Sunny (day)
+                return 'wi-day-sunny';
+            case 2: // Mostly Sunny (day)
+            case 3: // Partly Sunny (day)
+            case 4: // Intermittent Clouds (day)
+            case 5: // Hazy Sunshine (day)
+            case 6: // Mostly Cloudy (day)
+                return 'wi-day-cloudy';
+            case 7: // Cloudy (day, night)
+            case 8: // Dreary (Overcast) (day, night)
+                return 'wi-cloudy';
+            case 11: // Fog (day, night)
+                return 'wi-fog';
+            case 12: // Showers (day, night)
+                return 'wi-showers';
+            case 13: // Mostly Cloudy w/ Showers (day)
+            case 14: // Partly Sunny w/ Showers (day)
+                return 'wi-day-showers';
+            case 15: // T-Storms (day, night)
+                return 'wi-thunderstorm';
+            case 16: // Mostly Cloudy w/ T-Storms (day)
+            case 17: // Partly Sunny w/ T-Storms (day)
+                return 'wi-day-thunderstorms';
+            case 18: // Rain (day, night)
+                return 'wi-rain';
+            case 19: // Flurries (day, night)
+                return 'wi-snow';
+            case 20: // Mostly Cloudy w/ Flurries (day)
+            case 21: // Partly Sunny w/ Flurries (day)
+                return 'wi-day-snow';
+            case 22: // Snow (day, night)
+                return 'wi-snow';
+            case 23: // Mostly Cloudy w/ Snow (day)
+                return 'wi-day-snow';
+            case 24: // Ice (day, night)
+                return 'wi-snowflake-cold';
+            case 25: // Sleet (day, night)
+            case 26: // Freezing Rain (day, night)
+                return 'wi-sleet';
+            case 29: // Rain and Snow (day, night)
+                return 'wi-rain-mix';
+            case 30: // Hot (day, night)
+                return 'wi-hot';
+            case 31: // Cold (day, night)
+                return 'wi-snowflake-cold';
+            case 32: // Windy (day, night)
+                return 'wi-windy';
+            case 33: // Clear (night)
+                return 'wi-night-clear';
+            case 34: // Mostly Clear (night)
+            case 35: // Partly Cloudy (night)
+            case 36: // Intermittent Clouds (night)
+            case 37: // Hazy Moonlight (night)
+            case 38: // Mostly Cloudy (night)
+                return 'wi-night-alt-cloudy';
+            case 39: // Partly Cloudy w/ Showers (night)
+            case 40: // Mostly Cloudy w/ Showers (night)
+                return 'wi-night-alt-showers';
+            case 41: // Partly Cloudy w/ T-Storms (night)
+            case 42: // Mostly Cloudy w/ T-Storms (night)
+                return 'wi-night-alt-thunderstorm';
+            case 43: // Mostly Cloudy w/ Flurries (night)
+            case 44: // Mostly Cloudy w/ Snow (night)
+                return 'wi-night-snow';
+                break;
+            default:
+                return 'wi-na';
+        }
+    }
+}

--- a/tests/Statusboard/Weather/Accuweather/TransformTest.php
+++ b/tests/Statusboard/Weather/Accuweather/TransformTest.php
@@ -227,6 +227,10 @@ class TransformTest extends TestCase {
                     "day" => "Sunny",
                     "night" => "Mostly cloudy",
                 ],
+                "weather-icons" => [
+                    "day" => "wi-day-sunny",
+                    "night" => "wi-night-alt-cloudy",
+                ],
             ],
             1 => [
                 "date" => 1578657600,
@@ -240,6 +244,10 @@ class TransformTest extends TestCase {
                 "icontext" => [
                     "day" => "Mostly cloudy",
                     "night" => "Mostly cloudy",
+                ],
+                "weather-icons" => [
+                    "day" => "wi-day-cloudy",
+                    "night" => "wi-night-alt-cloudy",
                 ],
             ],
             2 => [
@@ -255,6 +263,10 @@ class TransformTest extends TestCase {
                     "day" => "Mostly cloudy",
                     "night" => "Light Rain Cloudy",
                 ],
+                "weather-icons" => [
+                    "day" => "wi-day-cloudy",
+                    "night" => "wi-cloudy",
+                ],
             ],
             3 => [
                 "date" => 1578830400,
@@ -268,6 +280,10 @@ class TransformTest extends TestCase {
                 "icontext" => [
                     "day" => "Moderate Rain Showers",
                     "night" => "Partly cloudy",
+                ],
+                "weather-icons" => [
+                    "day" => "wi-showers",
+                    "night" => "wi-night-alt-cloudy",
                 ],
             ],
             4 => [
@@ -283,6 +299,10 @@ class TransformTest extends TestCase {
                     "day" => "Intermittent clouds",
                     "night" => "Mostly clear",
                 ],
+                "weather-icons" => [
+                    "day" => "wi-day-cloudy",
+                    "night" => "wi-night-alt-cloudy",
+                ],
             ],
             "headline" => "Becoming noticeably warmer tomorrow and Saturday",
             "expires" => 1578590626,
@@ -291,7 +311,8 @@ class TransformTest extends TestCase {
                 "temp" => 26,
                 "link" => "http://www.accuweather.com/en/us/milford-ma/01757/current-weather/593_pc?lang=en-us",
                 "icon" => "assets/images/weather/accuweather/01-s.png",
-            ]
+                "weather-icon" =>  "wi-day-sunny"
+            ],
         ];
     }
 

--- a/web/assets/js/WeatherInfo.js
+++ b/web/assets/js/WeatherInfo.js
@@ -48,6 +48,9 @@ $.widget("howe.WeatherInfo",{
                     me.__Error('Ajax Request Timeout');
                 }
                 if(status === 'error'){
+                    if(xhr.status === 403){
+                        me.__Error('Request volume has been exceeded for today');
+                    }
                     me.__Error('Internal Server Error');
                 }
                 let error = JSON.parse(xhr.responseText);
@@ -81,7 +84,8 @@ $.widget("howe.WeatherInfo",{
             "<div class='row'>",
             "<div class='col-lg-3 col-md-3 col-sm-12'><div class='panel panel-warning'><div class='panel-heading text-center'>",
             me.data_response['current']['condition'] + "<br>Currently: " + me.data_response['current']['temp'] + " &deg;F<br>",
-            "<a target='_blank' href='" + me.data_response['current']['link'] + "'><img src='" + me.data_response['current']['icon'] + "' alt='" + me.data_response['current']['condition'] + "'></a><br>",
+            "<a target='_blank' href='" + me.data_response['current']['link'] + "'>",
+            "<i class='wi " + me.data_response['current']['weather-icon'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i></a><br>",
             "</div></div></div>",
             "<div class='col-lg-9 col-md-9 col-sm-12' title='updated: " + me.__convertTimestamp(Math.floor(new Date().getTime()/1000.0)) + ", expires: " + me.__convertTimestamp(me.data_response['expires']) + "'><div class='panel panel-success'><div class='panel-heading text-center'>" + me.data_response['headline'] + "</div></div></div>",
             "</div>",
@@ -92,9 +96,9 @@ $.widget("howe.WeatherInfo",{
             "<div class='panel-body text-center'>",
             "High: " + me.data_response[0]['hightemp'] + " &deg;F<br>",
             "Low: " + me.data_response[0]['lowtemp'] + " &deg;F<br>",
-            "<img src='" + me.data_response[0]['icons']['day'] + "' alt='" + me.data_response[0]['icontext']['day'] + "'><br>",
+            "<i class='wi " + me.data_response[0]['weather-icons']['day'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[0]['icontext']['day'] + "<br>",
-            "<img src='" + me.data_response[0]['icons']['night'] + "' alt='" + me.data_response[0]['icontext']['night'] + "'><br>",
+            "<i class='wi " + me.data_response[0]['weather-icons']['night'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[0]['icontext']['night'],
             "</div>",
             "</div>",
@@ -105,9 +109,9 @@ $.widget("howe.WeatherInfo",{
             "<div class='panel-body text-center'>",
             "High: " + me.data_response[1]['hightemp'] + " &deg;F<br>",
             "Low: " + me.data_response[1]['lowtemp'] + " &deg;F<br>",
-            "<img src='" + me.data_response[1]['icons']['day'] + "' alt='" + me.data_response[1]['icontext']['day'] + "'><br>",
+            "<i class='wi " + me.data_response[1]['weather-icons']['day'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[1]['icontext']['day'] + "<br>",
-            "<img src='" + me.data_response[1]['icons']['night'] + "' alt='" + me.data_response[1]['icontext']['night'] + "'><br>",
+            "<i class='wi " + me.data_response[1]['weather-icons']['night'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[1]['icontext']['night'],
             "</div>",
             "</div>",
@@ -118,9 +122,9 @@ $.widget("howe.WeatherInfo",{
             "<div class='panel-body text-center'>",
             "High: " + me.data_response[2]['hightemp'] + " &deg;F<br>",
             "Low: " + me.data_response[2]['lowtemp'] + " &deg;F<br>",
-            "<img src='" + me.data_response[2]['icons']['day'] + "' alt='" + me.data_response[2]['icontext']['day'] + "'><br>",
+            "<i class='wi " + me.data_response[2]['weather-icons']['day'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[2]['icontext']['day'] + "<br>",
-            "<img src='" + me.data_response[2]['icons']['night'] + "' alt='" + me.data_response[2]['icontext']['night'] + "'><br>",
+            "<i class='wi " + me.data_response[2]['weather-icons']['night'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[2]['icontext']['night'],
             "</div>",
             "</div>",
@@ -131,9 +135,9 @@ $.widget("howe.WeatherInfo",{
             "<div class='panel-body text-center'>",
             "High: " + me.data_response[3]['hightemp'] + " &deg;F<br>",
             "Low: " + me.data_response[3]['lowtemp'] + " &deg;F<br>",
-            "<img src='" + me.data_response[3]['icons']['day'] + "' alt='" + me.data_response[3]['icontext']['day'] + "'><br>",
+            "<i class='wi " + me.data_response[3]['weather-icons']['day'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[3]['icontext']['day'] + "<br>",
-            "<img src='" + me.data_response[3]['icons']['night'] + "' alt='" + me.data_response[3]['icontext']['night'] + "'><br>",
+            "<i class='wi " + me.data_response[3]['weather-icons']['night'] + "' style='color:#401718; font-size:2em; padding-top: 8px;'></i><br>",
             me.data_response[3]['icontext']['night'],
             "</div>",
             "</div>",


### PR DESCRIPTION
* Added weatherimage package to package.json at version 2.0.x
* Added reference to weather images css file in base.html.twig
* Added translation class to Accuweather to translate icons to css classes
* Added to the Transform::responseProcessor() output additional references to the weathericon css classes
* Updated the Accuweather TransformTest.php to check for the newly added output