### PR TITLE
MBTA route name change hotfix

### DIFF
--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -193,8 +193,7 @@ class ApiController extends Controller
         } else {
             try {
                 $trip_filters = [
-                    TripFilters::tripDirectionFilter(TripFilters::TRIP_OUTBOUND),
-                    TripFilters::routePatternFilter(MbtaFetcher::ROUTE_PATTERN)
+                    TripFilters::headSignFilter(TripFilters::HEADSIGN_FORGEPARK)
                 ];
                 $schedule = MbtaFetcher::getSchedule($api_key, $trip_filters);
                 $expiration_time = Mbta::getExpirationTime($schedule, time());

--- a/src/Statusboard/Mbta/TripFilters.php
+++ b/src/Statusboard/Mbta/TripFilters.php
@@ -9,6 +9,8 @@ class TripFilters {
     const TRIP_OUTBOUND = 0;
     const TRIP_INBOUND = 1;
 
+    const HEADSIGN_FORGEPARK = "Forge Park/495";
+
     public static function tripDirectionFilter($trip_direction){
         if(!self::validateTripDirection($trip_direction)) throw new \InvalidArgumentException('Invalid trip direction \'' . $trip_direction . '\'');
         return function($trip) use ($trip_direction) {
@@ -19,9 +21,21 @@ class TripFilters {
         };
     }
 
+    /**
+     * @deprecated The route patter has changed and is no longer a reliable filter
+     */
     public static function routePatternFilter($route_pattern){
         return function ($trip) use ($route_pattern) {
             if ($trip['relationships']['route_pattern']['data']['id'] === $route_pattern) {
+                return true;
+            }
+            return false;
+        };
+    }
+
+    public static function headSignFilter($headsign){
+        return function ($trip) use ($headsign) {
+            if ($trip['attributes']['headsign'] === $headsign) {
                 return true;
             }
             return false;


### PR DESCRIPTION
* the MBTA api changed the way it named the routes causing it to no longer be a reliable filter
* added a new TripFilters for filtering trips on headsigns which has a direction implicitly included in it