### PR TITLE
Issue #66 weather cache clear

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -51,7 +51,8 @@ class DefaultController extends Controller
             'arrival_time' => $arrival_time,
             'add_time'     => $add_time,
             'servers'      => $servers,
-            'events'       => $nextEvents
+            'events'       => $nextEvents,
+            'baseUrl'      => $this->container->get('router')->getContext()->getBaseUrl() . "/"
         ]);
     }
 

--- a/src/AppBundle/Resources/views/Admin/mbta.html.twig
+++ b/src/AppBundle/Resources/views/Admin/mbta.html.twig
@@ -30,15 +30,13 @@
 {% block javascripts %}
     <script src="{{ asset('assets/js/Mbta.js') }}"></script>
     <script>
-
         $(function () {
             $('.mbta').Mbta({baseUrl: "{{ baseUrl }}"});
-            $('body').on('click', '.reset_mbta', updateMbta);
+            $('body').on('click', '.reset_mbta', performReset("{{ baseUrl }}api/weather/reset"));
         });
-
-        function updateMbta(){
+        function performReset(endpoint){
             $.ajax({
-                url: "api/mbta/reset",
+                url: endpoint,
                 method: 'GET',
                 dataType:'json',
                 async: true,
@@ -64,6 +62,5 @@
                 }
             });
         }
-
     </script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Admin/mbta.html.twig
+++ b/src/AppBundle/Resources/views/Admin/mbta.html.twig
@@ -32,7 +32,7 @@
     <script>
         $(function () {
             $('.mbta').Mbta({baseUrl: "{{ baseUrl }}"});
-            $('body').on('click', '.reset_mbta', performReset("{{ baseUrl }}api/weather/reset"));
+            $('body').on('click', '.reset_mbta', () => { performReset("{{ baseUrl }}api/mbta/reset"); });
         });
         function performReset(endpoint){
             $.ajax({

--- a/src/AppBundle/Resources/views/Admin/weather.html.twig
+++ b/src/AppBundle/Resources/views/Admin/weather.html.twig
@@ -12,7 +12,7 @@
             <div class="panel panel-info">
                 <div class="panel-heading">
                     <div class="panel-title text-center">
-                        <i class="fa fa-cloud fa-fw"></i> Weather
+                        <i class="fa fa-cloud fa-fw reset_weather"></i> Weather
                     </div>
                 </div>
                 <div class="panel-body">
@@ -32,6 +32,35 @@
     <script>
         $(function () {
             $('.weather').WeatherInfo({baseUrl: "{{ baseUrl }}"});
+            $('body').on('click', '.reset_weather', performReset("{{ baseUrl }}api/weather/reset"));
         });
+        function performReset(endpoint){
+            $.ajax({
+                url: endpoint,
+                method: 'GET',
+                dataType:'json',
+                async: true,
+                cache: false,
+                timeout: 5*1000,
+                success: function(data, status){
+                    if(status === 'timeout'){
+                        alert('Time out!');
+                    }
+                    if(status === 'nocontent'){
+                        alert('No Content');
+                    }
+                    alert(data);
+                },
+                error: function(xhr, status){
+                    if(status === 'timeout'){
+                        alert('Time out!');
+                    }
+                    if(status === 'nocontent'){
+                        alert('No Content');
+                    }
+                    alert('failed to clear cache');
+                }
+            });
+        }
     </script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Admin/weather.html.twig
+++ b/src/AppBundle/Resources/views/Admin/weather.html.twig
@@ -32,7 +32,7 @@
     <script>
         $(function () {
             $('.weather').WeatherInfo({baseUrl: "{{ baseUrl }}"});
-            $('body').on('click', '.reset_weather', performReset("{{ baseUrl }}api/weather/reset"));
+            $('body').on('click', '.reset_weather', () => { performReset("{{ baseUrl }}api/weather/reset"); });
         });
         function performReset(endpoint){
             $.ajax({

--- a/src/AppBundle/Resources/views/Default/index.html.twig
+++ b/src/AppBundle/Resources/views/Default/index.html.twig
@@ -191,8 +191,8 @@
                 }
             });
             $('body')
-                .on('click', '.reset_mbta', performReset("{{ baseUrl }}api/mbta/reset"))
-                .on('click', '.reset_weather', performReset("{{ baseUrl }}api/weather/reset"));
+                .on('click', '.reset_mbta', () => { performReset("{{ baseUrl }}api/mbta/reset"); })
+                .on('click', '.reset_weather', () => { performReset("{{ baseUrl }}api/weather/reset"); });
         });
 
         /**

--- a/src/AppBundle/Resources/views/Default/index.html.twig
+++ b/src/AppBundle/Resources/views/Default/index.html.twig
@@ -22,7 +22,7 @@
                         {% endif %}
                             <div class="col-md-12 col-lg-4">
                                 <button style="display: none;" type="button"
-                                        class="btn btn-primary btn-lg btn-block serverinfo" data-server="{{ server.name }}"{% if server.isDisabled %} data-disabled="true"{% endif %}></button>
+                                        class="btn btn-primary btn-lg btn-block serverinfo" data-server="{{ server.name }}"{% if server.isDisabled %} data-disabled="true"{% endif %} data-baseurl="{{ baseUrl }}"></button>
                             </div>
                         {% if loop.index is divisible by (3) %}
                             {% if loop.last %}
@@ -128,7 +128,7 @@
             <div class="panel panel-info">
                 <div class="panel-heading">
                     <div class="panel-title text-center">
-                        <i class="fa fa-cloud fa-fw"></i> Weather
+                        <i class="fa fa-cloud fa-fw reset_weather"></i> Weather
                     </div>
                 </div>
                 <div class="panel-body">
@@ -177,8 +177,8 @@
             setInterval('updateTime()', 1000);
             displayTime();
             setInterval('displayTime()', 1000);
-            $('.weather').WeatherInfo();
-            $('.mbta').Mbta();
+            $('.weather').WeatherInfo({baseUrl: "{{ baseUrl }}"});
+            $('.mbta').Mbta({baseUrl: "{{ baseUrl }}"});
             $('.serverinfo').ServerInfo();
             $(".jquery_ui_datepicker_preview").datepicker({
                 defaultDate: null,
@@ -190,7 +190,9 @@
                     return PersonalCalendar.parseDate(currentDate);
                 }
             });
-            $('body').on('click', '.reset_mbta', updateMbta);
+            $('body')
+                .on('click', '.reset_mbta', performReset("{{ baseUrl }}api/mbta/reset"))
+                .on('click', '.reset_weather', performReset("{{ baseUrl }}api/weather/reset"));
         });
 
         /**
@@ -254,9 +256,9 @@
 
         }
 
-        function updateMbta(){
+        function performReset(endpoint){
             $.ajax({
-                url: "api/mbta/reset",
+                url: endpoint,
                 method: 'GET',
                 dataType:'json',
                 async: true,


### PR DESCRIPTION
This implemented a cache clear button for the weather api in a similar fashion to the current mbta one.  The implementation was made more generic so it could just accept an end point and accomplish the same functionality.  Also implemented the use of the baseUrl throughout the solution for all api calls.